### PR TITLE
Add AnalystAgent with analyzeRequirement tool

### DIFF
--- a/agent-analyst/pom.xml
+++ b/agent-analyst/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mas</groupId>
+    <artifactId>agent-analyst</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>MAS Analyst Agent</name>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Java SDK -->
+        <dependency>
+            <groupId>com.modelcontext</groupId>
+            <artifactId>mcp-sdk</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.mas.analyst.AnalystAgent</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/agent-analyst/src/main/java/com/mas/analyst/AnalystAgent.java
+++ b/agent-analyst/src/main/java/com/mas/analyst/AnalystAgent.java
@@ -1,0 +1,43 @@
+package com.mas.analyst;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.modelcontext.mcp.server.McpServer;
+import com.modelcontext.mcp.tool.Tool;
+import com.modelcontext.mcp.tool.ToolRequest;
+import com.modelcontext.mcp.tool.ToolResponse;
+
+/**
+ * Simple Analyst Agent exposing an analyzeRequirement tool using MCP.
+ */
+public class AnalystAgent {
+
+    public static void main(String[] args) throws Exception {
+        McpServer server = new McpServer();
+        server.registerTool(analyzeRequirementTool());
+        server.start();
+    }
+
+    private static Tool analyzeRequirementTool() {
+        return Tool.builder()
+                .name("analyzeRequirement")
+                .description("Analyze a requirement and return user stories")
+                .addParameter("requirement", String.class)
+                .handler(AnalystAgent::handleAnalyzeRequirement)
+                .build();
+    }
+
+    private static ToolResponse handleAnalyzeRequirement(ToolRequest request) {
+        String requirement = request.getString("requirement");
+        List<String> stories = new ArrayList<>();
+        if (requirement != null && !requirement.isBlank()) {
+            stories.add("As a user, I want " + requirement);
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("user_stories", stories);
+        return ToolResponse.from(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `agent-analyst` Maven module
- include MCP Java SDK dependency
- implement `AnalystAgent` that starts an MCP server and registers the `analyzeRequirement` tool

## Testing
- `mvn -q -f agent-analyst/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_688951ad95c48325a724ff7d41d87721