### PR TITLE
Add TesterAgent with MCP runTest tool

### DIFF
--- a/agent-tester/pom.xml
+++ b/agent-tester/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mas</groupId>
+    <artifactId>agent-tester</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>MAS Tester Agent</name>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Java SDK -->
+        <dependency>
+            <groupId>com.modelcontext</groupId>
+            <artifactId>mcp-sdk</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.mas.tester.TesterAgent</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/agent-tester/src/main/java/com/mas/tester/TesterAgent.java
+++ b/agent-tester/src/main/java/com/mas/tester/TesterAgent.java
@@ -1,0 +1,43 @@
+package com.mas.tester;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.modelcontext.mcp.server.McpServer;
+import com.modelcontext.mcp.tool.Tool;
+import com.modelcontext.mcp.tool.ToolRequest;
+import com.modelcontext.mcp.tool.ToolResponse;
+
+/**
+ * Simple Tester Agent exposing a runTest tool using MCP.
+ */
+public class TesterAgent {
+
+    public static void main(String[] args) throws Exception {
+        McpServer server = new McpServer();
+        server.registerTool(runTestTool());
+        server.start();
+    }
+
+    private static Tool runTestTool() {
+        return Tool.builder()
+                .name("runTest")
+                .description("Run tests on provided code")
+                .addParameter("code", String.class)
+                .handler(TesterAgent::handleRunTest)
+                .build();
+    }
+
+    private static ToolResponse handleRunTest(ToolRequest request) {
+        String code = request.getString("code");
+        Map<String, Object> result = new HashMap<>();
+        if (code != null && code.contains("FAIL")) {
+            result.put("result", "FAIL");
+            result.put("details", "Code contains FAIL keyword");
+        } else {
+            result.put("result", "OK");
+            result.put("details", "Tests executed successfully");
+        }
+        return ToolResponse.from(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `agent-tester` Maven module
- include MCP Java SDK dependency
- implement `TesterAgent` main class exposing `runTest` tool

## Testing
- `mvn -q -f agent-tester/pom.xml -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_688951ea4814832587aa512d60e5f4df