### PR TITLE
Add orchestrator module with MCP workflow

### DIFF
--- a/orchestrator/pom.xml
+++ b/orchestrator/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mas</groupId>
+    <artifactId>orchestrator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>MAS Orchestrator</name>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Java SDK -->
+        <dependency>
+            <groupId>com.modelcontext</groupId>
+            <artifactId>mcp-sdk</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.mas.orchestrator.Orchestrator</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/orchestrator/src/main/java/com/mas/orchestrator/Orchestrator.java
+++ b/orchestrator/src/main/java/com/mas/orchestrator/Orchestrator.java
@@ -1,0 +1,57 @@
+package com.mas.orchestrator;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.List;
+
+import com.modelcontext.mcp.client.McpClient;
+import com.modelcontext.mcp.tool.ToolRequest;
+import com.modelcontext.mcp.tool.ToolResponse;
+
+/**
+ * Orchestrator that coordinates Analyst, Developer and Tester agents using MCP.
+ */
+public class Orchestrator {
+
+    public static void main(String[] args) throws Exception {
+        try (McpClient analyst = new McpClient("localhost", 8080);
+             McpClient developer = new McpClient("localhost", 8081);
+             McpClient tester = new McpClient("localhost", 8082);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+
+            System.out.print("Enter a requirement: ");
+            String requirement = reader.readLine();
+
+            ToolRequest analyzeReq = ToolRequest.builder()
+                    .toolName("analyzeRequirement")
+                    .addParam("requirement", requirement)
+                    .build();
+            ToolResponse analyzeResp = analyst.invoke(analyzeReq);
+            List<String> stories = analyzeResp.getList("user_stories", String.class);
+            if (stories.isEmpty()) {
+                System.out.println("No user stories produced");
+                return;
+            }
+            String story = stories.getFirst();
+            System.out.println("User story: " + story);
+
+            ToolRequest devReq = ToolRequest.builder()
+                    .toolName("generateCode")
+                    .addParam("user_story", story)
+                    .build();
+            ToolResponse devResp = developer.invoke(devReq);
+            String code = devResp.getString("code");
+            System.out.println("Generated code:\n" + code);
+
+            ToolRequest testReq = ToolRequest.builder()
+                    .toolName("runTest")
+                    .addParam("code", code)
+                    .build();
+            ToolResponse testResp = tester.invoke(testReq);
+            String result = testResp.getString("result");
+            String details = testResp.getString("details");
+            System.out.println("Test result: " + result);
+            System.out.println("Details: " + details);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `orchestrator` Maven module
- include MCP Java SDK dependency
- implement `Orchestrator` that calls AnalystAgent, DeveloperAgent and TesterAgent servers

## Testing
- `mvn -q -f orchestrator/pom.xml package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_688952eac90083258c9445883ca1a780