### PR TITLE
Add FileWriterAgent module

### DIFF
--- a/agent-filewriter/pom.xml
+++ b/agent-filewriter/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mas</groupId>
+    <artifactId>agent-filewriter</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>MAS File Writer Agent</name>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Java SDK -->
+        <dependency>
+            <groupId>com.modelcontext</groupId>
+            <artifactId>mcp-sdk</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.mas.filewriter.FileWriterAgent</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/agent-filewriter/src/main/java/com/mas/filewriter/FileWriterAgent.java
+++ b/agent-filewriter/src/main/java/com/mas/filewriter/FileWriterAgent.java
@@ -1,0 +1,63 @@
+package com.mas.filewriter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.modelcontext.mcp.server.McpServer;
+import com.modelcontext.mcp.tool.Tool;
+import com.modelcontext.mcp.tool.ToolRequest;
+import com.modelcontext.mcp.tool.ToolResponse;
+
+/**
+ * Agent that exposes a saveFile tool using MCP.
+ */
+public class FileWriterAgent {
+
+    private static final Logger LOGGER = Logger.getLogger(FileWriterAgent.class.getName());
+
+    public static void main(String[] args) throws Exception {
+        McpServer server = new McpServer();
+        server.registerTool(saveFileTool());
+        server.start();
+    }
+
+    private static Tool saveFileTool() {
+        return Tool.builder()
+                .name("saveFile")
+                .description("Save content to a file")
+                .addParameter("filename", String.class)
+                .addParameter("content", String.class)
+                .handler(FileWriterAgent::handleSaveFile)
+                .build();
+    }
+
+    private static ToolResponse handleSaveFile(ToolRequest request) {
+        String filename = request.getString("filename");
+        String content = request.getString("content");
+
+        String outputDirEnv = System.getenv().getOrDefault("OUTPUT_DIR", "output");
+        Path outDir = Paths.get(outputDirEnv);
+        Path filePath = outDir.resolve(filename);
+
+        Map<String, Object> result = new HashMap<>();
+        try {
+            Files.createDirectories(outDir);
+            Files.writeString(filePath, content == null ? "" : content, StandardCharsets.UTF_8);
+            result.put("status", "OK");
+            result.put("path", filePath.toAbsolutePath().toString());
+            LOGGER.info("Wrote file: " + filePath.toAbsolutePath());
+        } catch (IOException ex) {
+            LOGGER.log(Level.SEVERE, "Failed to write file: " + filePath.toAbsolutePath(), ex);
+            result.put("status", "FAIL");
+            result.put("path", filePath.toAbsolutePath().toString());
+        }
+        return ToolResponse.from(result);
+    }
+}


### PR DESCRIPTION
## Summary
- create new `agent-filewriter` Maven module
- add MCP Java SDK dependency
- implement `FileWriterAgent` exposing a `saveFile` tool

## Testing
- `mvn -q -f agent-filewriter/pom.xml package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_b_688a0608e21083259c70ca8003e7d63b